### PR TITLE
Fix not compatible with core_privacy\local\metadata\null_provider::ge…

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -34,7 +34,7 @@ class provider implements \core_privacy\report\metadata\null_provider
      *
      * @return string
      */
-    public static function get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }


### PR DESCRIPTION
…t_reason(): string